### PR TITLE
Promopting connection issues outside the lib

### DIFF
--- a/Examples/iOS/LiveViewController.swift
+++ b/Examples/iOS/LiveViewController.swift
@@ -74,7 +74,7 @@ final class LiveViewController: UIViewController {
             publish.setTitle("●", for: [])
         } else {
             UIApplication.shared.isIdleTimerDisabled = true
-            connection.connect(URL(string: Preference.shared.url))
+            ((try? connection.connect(URL(string: Preference.shared.url))) as ()??)
             stream.publish(Preference.shared.streamName)
             publish.setTitle("■", for: [])
         }

--- a/Sources/SRT/SRTError.swift
+++ b/Sources/SRT/SRTError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum SRTError: Error {
+public enum SRTError: Error {
     case illegalState(message: String)
     case invalidArgument(message: String)
 }

--- a/Sources/SRT/SRTSocket.swift
+++ b/Sources/SRT/SRTSocket.swift
@@ -66,17 +66,14 @@ class SRTSocket {
         }
 
         // prepare socket
-        socket = srt_socket(AF_INET, SOCK_DGRAM, 0)
-        if socket == SRT_ERROR {
-                let error_message = String(cString: srt_getlasterror_str())
-
-                logger.error(error_message)
-                throw SRTError.illegalState(message: error_message)
+        socket = srt_create_socket()
+        if socket == SRT_INVALID_SOCK {
+            throw createConnectionException()
         }
 
         self.options = options
         guard configure(.pre) else {
-            return
+            throw createConnectionException()
         }
 
         // prepare connect
@@ -87,18 +84,21 @@ class SRTSocket {
         }
 
         if stat == SRT_ERROR {
-
-            let error_message = String(cString: srt_getlasterror_str())
-
-            logger.error(error_message)
-            throw SRTError.illegalState(message: error_message)
+            throw createConnectionException()
         }
 
         guard configure(.post) else {
-            return
+            throw createConnectionException()
         }
 
         startRunning()
+    }
+    
+    private func createConnectionException() -> SRTError {
+        let error_message = String(cString: srt_getlasterror_str())
+
+        logger.error(error_message)
+        return SRTError.illegalState(message: error_message)
     }
 
     func close() {


### PR DESCRIPTION
Throwing errors in the connect call if somethings goes wrong
Added a dynamic `connectionBroken` property that can be observed to detect when the network connection is dropped